### PR TITLE
Fix Transaction::toString call

### DIFF
--- a/src/main/java/me/pagar/model/Transaction.java
+++ b/src/main/java/me/pagar/model/Transaction.java
@@ -17,8 +17,6 @@ import java.util.Map;
 
 public class Transaction extends PagarMeModel<Integer> {
 
-    private Integer id;
-
     @Expose(deserialize = false)
     private Boolean async;
 

--- a/src/test/java/me/pagarme/TransactionTest.java
+++ b/src/test/java/me/pagarme/TransactionTest.java
@@ -105,6 +105,14 @@ public class TransactionTest extends BaseTest {
     }
 
     @Test
+    public void testTransactionCanBeMadeString() throws Throwable {
+
+        transaction = this.transactionCreditCardCommon();
+
+        transaction.toString();
+    }
+
+    @Test
     public void testTransactionAuthAndCaptureCapturePartialValue() throws Throwable {
 
         transaction = this.transactionCreditCardCommon();


### PR DESCRIPTION
This PR fixes a duplicated `id` attribute declared in `Transaction` model.

As `Transaction` class inherits from `PagarMeModel`, it already have an `id` field defined coming from the inheritance chain. For an unknown reason, the field was redefined in `Transaction` class, causing Gson to throw an exception when serializing the class on `toString` call. This PR fixes this case and also adds a test case for the fix.