### PR TITLE
datetimeadapter: fix date serialization

### DIFF
--- a/src/main/java/me/pagar/util/DateTimeAdapter.java
+++ b/src/main/java/me/pagar/util/DateTimeAdapter.java
@@ -3,6 +3,7 @@ package me.pagar.util;
 import com.google.common.base.Strings;
 import com.google.gson.*;
 import org.joda.time.DateTime;
+import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;
 
@@ -13,9 +14,7 @@ public class DateTimeAdapter  implements JsonDeserializer<DateTime>, JsonSeriali
     private final DateTimeFormatter formatter;
 
     public DateTimeAdapter() {
-        this.formatter = ISODateTimeFormat
-                .dateOptionalTimeParser()
-                .withZoneUTC();
+        this.formatter = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ssZ");
     }
 
     @Override


### PR DESCRIPTION
Was reported by Happy Delivery that toJSon wasn't working as expected. The report included the following stack trace:

```
testTransactionCanBeMadeJSON(me.pagarme.TransactionTest)  Time elapsed: 0.845 sec  <<< ERROR!
java.lang.UnsupportedOperationException: Printing not supported
    at org.joda.time.format.DateTimeFormatter.requirePrinter(DateTimeFormatter.java:741)
    at org.joda.time.format.DateTimeFormatter.print(DateTimeFormatter.java:669)
    at me.pagar.util.DateTimeAdapter.serialize(DateTimeAdapter.java:33)
    at me.pagar.util.DateTimeAdapter.serialize(DateTimeAdapter.java:11)
    at com.google.gson.internal.bind.TreeTypeAdapter.write(TreeTypeAdapter.java:81)
    at com.google.gson.internal.bind.TypeAdapterRuntimeTypeWrapper.write(TypeAdapterRuntimeTypeWrapper.java:69)
    at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$1.write(ReflectiveTypeAdapterFactory.java:125)
    at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.write(ReflectiveTypeAdapterFactory.java:243)
    at com.google.gson.internal.bind.TypeAdapterRuntimeTypeWrapper.write(TypeAdapterRuntimeTypeWrapper.java:69)
    at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$1.write(ReflectiveTypeAdapterFactory.java:125)
    at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.write(ReflectiveTypeAdapterFactory.java:243)
    at com.google.gson.Gson.toJson(Gson.java:669)
    at com.google.gson.Gson.toJson(Gson.java:648)
    at com.google.gson.Gson.toJson(Gson.java:603)
    at com.google.gson.Gson.toJson(Gson.java:583)
    at me.pagar.model.PagarMeModel.toJson(PagarMeModel.java:175)
    at me.pagarme.TransactionTest.testTransactionCanBeMadeJSON(TransactionTest.java:128)

```

We change the date time formatter so that we can print dates in iso format using the same formatter.