### PR TITLE
chore: use git tags on maven deploy script

### DIFF
--- a/deploy-to-maven.sh
+++ b/deploy-to-maven.sh
@@ -7,9 +7,9 @@ mvn package
 mvn source:jar
 mvn javadoc:jar
 
-echo "Please confirm the deployment version."
-read DEPVERSION
+DEPVERSION=$(git describe --tags --always HEAD)
 
 mvn gpg:sign-and-deploy-file -Durl=https://oss.sonatype.org/service/local/staging/deploy/maven2 -DrepositoryId=ossrh -DpomFile=pom.xml -Dfile=target/pagarme-java-${DEPVERSION}.jar 
 mvn gpg:sign-and-deploy-file -Durl=https://oss.sonatype.org/service/local/staging/deploy/maven2 -DrepositoryId=ossrh -DpomFile=pom.xml -Dfile=target/pagarme-java-${DEPVERSION}-sources.jar -Dclassifier=sources
 mvn gpg:sign-and-deploy-file -Durl=https://oss.sonatype.org/service/local/staging/deploy/maven2 -DrepositoryId=ossrh -DpomFile=pom.xml -Dfile=target/pagarme-java-${DEPVERSION}-javadoc.jar -Dclassifier=javadoc
+


### PR DESCRIPTION
Use git tags when deploying to maven. This makes packaging always in sync with versioning.