### PR TITLE
localdateformat: fix local date adapter

### DIFF
--- a/src/main/java/me/pagar/util/LocalDateAdapter.java
+++ b/src/main/java/me/pagar/util/LocalDateAdapter.java
@@ -4,6 +4,7 @@ import com.google.common.base.Strings;
 import com.google.gson.*;
 import org.joda.time.LocalDate;
 import org.joda.time.format.DateTimeFormatter;
+import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.ISODateTimeFormat;
 
 import java.lang.reflect.Type;
@@ -13,8 +14,7 @@ public class LocalDateAdapter implements JsonDeserializer<LocalDate>, JsonSerial
     private final DateTimeFormatter formatter;
 
     public LocalDateAdapter() {
-        this.formatter = ISODateTimeFormat
-                .localDateParser();
+        this.formatter = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ssZ");
     }
 
     @Override

--- a/src/test/java/me/pagarme/BaseTest.java
+++ b/src/test/java/me/pagarme/BaseTest.java
@@ -3,6 +3,7 @@ package me.pagarme;
 import me.pagar.model.*;
 import org.junit.Assert;
 import org.omg.CORBA.Object;
+import org.joda.time.LocalDate;
 
 public abstract class BaseTest {
 
@@ -127,6 +128,7 @@ public abstract class BaseTest {
      * @return
      */
     protected Transaction transactionBoletoCommon() {
+        transaction.setBoletoExpirationDate(LocalDate.now().plusDays(4));
         transaction.setAmount(100);
         transaction.setPaymentMethod(Transaction.PaymentMethod.BOLETO);
         return transaction;


### PR DESCRIPTION
A client reported that he can't use transaction.setBoletoExpirationDate(), because LocalDate throws the following message: java.lang.UnsupportedOperationException: Printing not supported