### PR TITLE
softdesc: add @expose to soft desc property

### DIFF
--- a/src/main/java/me/pagar/model/Transaction.java
+++ b/src/main/java/me/pagar/model/Transaction.java
@@ -237,6 +237,7 @@ public class Transaction extends PagarMeModel<Integer> {
      * Texto que irá aparecer na fatura do cliente depois do nome da loja.
      * <b>OBS:</b> Limite de 13 caracteres.
      */
+    @Expose
     @SerializedName("soft_descriptor")
     private String softDescriptor;
 

--- a/src/test/java/me/pagarme/TransactionTest.java
+++ b/src/test/java/me/pagarme/TransactionTest.java
@@ -68,6 +68,18 @@ public class TransactionTest extends BaseTest {
     }
 
     @Test
+    public void testCreateAndCaptureTransactionWithSoftDescriptor() throws Throwable {
+
+        transaction = this.transactionCreditCardCommon();
+        transaction.setSoftDescriptor("API Test");
+        transaction.save();
+
+        Assert.assertEquals(transaction.getPaymentMethod(), Transaction.PaymentMethod.CREDIT_CARD);
+        Assert.assertEquals(transaction.getStatus(), Transaction.Status.PAID);
+        Assert.assertEquals(transaction.getSoftDescriptor(), "API Test");
+    }
+
+    @Test
     public void testCreateAndCaptureTransactionWithCreditCardWithoutGoingThroughFraud() throws Throwable {
 
         transaction = this.transactionCreditCardCommon();


### PR DESCRIPTION
A client tried to use the soft_descriptor but the property wasn't exposed