### PR TITLE
Fix postback validation

### DIFF
--- a/src/main/java/me/pagar/model/PagarMe.java
+++ b/src/main/java/me/pagar/model/PagarMe.java
@@ -40,7 +40,7 @@ public abstract class PagarMe {
     public static boolean isRequestSignatureValid(final String payload, final String signature) {
 
         if (Strings.isNullOrEmpty(signature)) {
-            return true;
+            return false;
         }
 
 	    String algorithm;
@@ -74,7 +74,7 @@ public abstract class PagarMe {
 
 		    //  Covert array of Hex bytes to a String
 		    String hash = new String(hexBytes, "UTF-8");
-		    return signature.equals(hash);
+		    return parts[1].equals(hash);
 	    } catch (Exception e) {
 		    return false;
 	    }

--- a/src/main/java/me/pagar/model/PagarMe.java
+++ b/src/main/java/me/pagar/model/PagarMe.java
@@ -43,41 +43,41 @@ public abstract class PagarMe {
             return false;
         }
 
-	    String algorithm;
-	    final String[] parts = signature.split("=");
+        String algorithm;
+        final String[] parts = signature.split("=");
 
-	    if (parts.length != 2) // Wrong signature param
-		    return false;
+        if (parts.length != 2) // Wrong signature param
+            return false;
 
-	    if (parts[0].equalsIgnoreCase(SHA1_ALGORITHM)) {
-		    algorithm = HMAC_SHA1_ALGORITHM;
-	    } else if (parts[0].equalsIgnoreCase(SHA256_ALGORITHM)) {
-		    algorithm = HMAC_SHA256_ALGORITHM;
-	    } else {
-			return false; // Cannot set algorithm.
-	    }
+        if (parts[0].equalsIgnoreCase(SHA1_ALGORITHM)) {
+            algorithm = HMAC_SHA1_ALGORITHM;
+        } else if (parts[0].equalsIgnoreCase(SHA256_ALGORITHM)) {
+            algorithm = HMAC_SHA256_ALGORITHM;
+        } else {
+            return false; // Cannot set algorithm.
+        }
 
-	    try {
-		    // Get hmac key from the raw key bytes
-		    byte[] keyBytes = apiKey.getBytes();
-		    SecretKeySpec signingKey = new SecretKeySpec(keyBytes, algorithm);
+        try {
+            // Get hmac key from the raw key bytes
+            byte[] keyBytes = apiKey.getBytes();
+            SecretKeySpec signingKey = new SecretKeySpec(keyBytes, algorithm);
 
-		    // Get hmac Mac instance and initialize with the signing key
-		    Mac mac = Mac.getInstance(algorithm);
-		    mac.init(signingKey);
+            // Get hmac Mac instance and initialize with the signing key
+            Mac mac = Mac.getInstance(algorithm);
+            mac.init(signingKey);
 
-		    // Compute the hmac on input data bytes
-		    byte[] rawHmac = mac.doFinal(payload.getBytes());
+            // Compute the hmac on input data bytes
+            byte[] rawHmac = mac.doFinal(payload.getBytes());
 
-		    // Convert raw bytes to Hex
-		    byte[] hexBytes = new Hex().encode(rawHmac);
+            // Convert raw bytes to Hex
+            byte[] hexBytes = new Hex().encode(rawHmac);
 
-		    //  Covert array of Hex bytes to a String
-		    String hash = new String(hexBytes, "UTF-8");
-		    return parts[1].equals(hash);
-	    } catch (Exception e) {
-		    return false;
-	    }
+            //  Covert array of Hex bytes to a String
+            String hash = new String(hexBytes, "UTF-8");
+            return parts[1].equals(hash);
+        } catch (Exception e) {
+            return false;
+        }
 
     }
 }

--- a/src/main/java/me/pagar/model/PagarMe.java
+++ b/src/main/java/me/pagar/model/PagarMe.java
@@ -37,14 +37,17 @@ public abstract class PagarMe {
         PagarMe.apiKey = apiKey;
     }
 
-    public static boolean validateRequestSignature(final String payload, final String signature) {
+    public static boolean isRequestSignatureValid(final String payload, final String signature) {
 
         if (Strings.isNullOrEmpty(signature)) {
             return true;
         }
 
 	    String algorithm;
-        final String[] parts = signature.split("=");
+	    final String[] parts = signature.split("=");
+
+	    if (parts.length != 2) // Wrong signature param
+		    return false;
 
 	    if (parts[0].equalsIgnoreCase(SHA1_ALGORITHM)) {
 		    algorithm = HMAC_SHA1_ALGORITHM;
@@ -70,7 +73,8 @@ public abstract class PagarMe {
 		    byte[] hexBytes = new Hex().encode(rawHmac);
 
 		    //  Covert array of Hex bytes to a String
-		    return signature.equals( new String(hexBytes, "UTF-8"));
+		    String hash = new String(hexBytes, "UTF-8");
+		    return signature.equals(hash);
 	    } catch (Exception e) {
 		    return false;
 	    }


### PR DESCRIPTION
HMAC SHA1 postback validation was generating wrong hash comparsion.

### Delivery

- Fix HMAC calc
- Change method name to use boolean validation pattern
- Remove unused constants.