### PR TITLE
Include capture with split rules

### DIFF
--- a/src/main/java/me/pagar/model/Transaction.java
+++ b/src/main/java/me/pagar/model/Transaction.java
@@ -1049,8 +1049,7 @@ public class Transaction extends PagarMeModel<Integer> {
         final PagarMeRequest request = new PagarMeRequest(HttpMethod.POST,
                 String.format("/%s/%s/capture", getClassName(), getId()));
         
-        if (amount != null)
-            request.getParameters().put("amount", amount);
+        request.getParameters().put("amount", amount);
         
         if (this.getMetadata() != null)
             request.getParameters().put("metadata", this.getMetadata());

--- a/src/main/java/me/pagar/model/Transaction.java
+++ b/src/main/java/me/pagar/model/Transaction.java
@@ -1048,12 +1048,12 @@ public class Transaction extends PagarMeModel<Integer> {
 
         final PagarMeRequest request = new PagarMeRequest(HttpMethod.POST,
                 String.format("/%s/%s/capture", getClassName(), getId()));
-        
+
         request.getParameters().put("amount", amount);
-        
+		
         if (this.getMetadata() != null)
             request.getParameters().put("metadata", this.getMetadata());
-        
+
         if (this.getSplitRules() != null)
             request.getParameters().put("split_rules", this.getSplitRules());
 

--- a/src/main/java/me/pagar/model/Transaction.java
+++ b/src/main/java/me/pagar/model/Transaction.java
@@ -1048,9 +1048,15 @@ public class Transaction extends PagarMeModel<Integer> {
 
         final PagarMeRequest request = new PagarMeRequest(HttpMethod.POST,
                 String.format("/%s/%s/capture", getClassName(), getId()));
-
-        request.getParameters().put("amount", amount);
-        request.getParameters().put("metadata", this.getMetadata());
+        
+        if (amount != null)
+            request.getParameters().put("amount", amount);
+        
+        if (this.getMetadata() != null)
+            request.getParameters().put("metadata", this.getMetadata());
+        
+        if (this.getSplitRules() != null)
+            request.getParameters().put("split_rules", this.getSplitRules());
 
         final Transaction other = JSONUtils.getAsObject((JsonObject) request.execute(), Transaction.class);
         copy(other);

--- a/src/test/java/me/pagarme/TransactionTest.java
+++ b/src/test/java/me/pagarme/TransactionTest.java
@@ -431,7 +431,6 @@ public class TransactionTest extends BaseTest {
         splitRule2.setChargeProcessingFee(true);
 
         splitRules.add(splitRule2);
-        //transaction.setSplitRules(splitRules);
         
         Assert.assertEquals(transaction.getStatus(), Transaction.Status.AUTHORIZED);
         transaction.setSplitRules(splitRules);


### PR DESCRIPTION
Enable set of split rules when the client is capturing a transaction. Hey @henriquekano, Can you take a look at it?