### PR TITLE
Alteração de tipo no atributo boletoExpirationDate (Transaction.java)

### DIFF
--- a/src/main/java/me/pagar/model/Transaction.java
+++ b/src/main/java/me/pagar/model/Transaction.java
@@ -7,7 +7,6 @@ import java.util.Map;
 import javax.ws.rs.HttpMethod;
 
 import org.joda.time.DateTime;
-import org.joda.time.LocalDate;
 
 import com.google.common.base.CaseFormat;
 import com.google.gson.JsonArray;
@@ -351,7 +350,7 @@ public class Transaction extends PagarMeModel<Integer> {
      */
     @Expose(deserialize = false)
     @SerializedName("boleto_expiration_date")
-    private LocalDate boletoExpirationDate;
+    private DateTime boletoExpirationDate;
 
     /**
      * Data de atualização da transação no formato ISODate
@@ -744,7 +743,7 @@ public class Transaction extends PagarMeModel<Integer> {
         addUnsavedProperty("customer");
     }
 
-    public void setBoletoExpirationDate(final LocalDate boletoExpirationDate) {
+    public void setBoletoExpirationDate(final DateTime boletoExpirationDate) {
         this.boletoExpirationDate = boletoExpirationDate;
         addUnsavedProperty("boletoExpirationDate");
     }

--- a/src/test/java/me/pagarme/TransactionTest.java
+++ b/src/test/java/me/pagarme/TransactionTest.java
@@ -354,11 +354,12 @@ public class TransactionTest extends BaseTest {
         Assert.assertNotNull(transaction.getBoletoBarcode());
     }
 
+    @Test
     public void testBoletoExpirationDate() throws Throwable{
         transaction = transactionFactory.createBoletoTransaction();
         transaction.save();
 
-        Assert.assertEquals(transaction.getBoletoExpirationDate(), DateTime.now().plusDays(4));
+        Assert.assertNotNull(transaction.getBoletoExpirationDate());
     }
 
     @Test

--- a/src/test/java/me/pagarme/factory/TransactionFactory.java
+++ b/src/test/java/me/pagarme/factory/TransactionFactory.java
@@ -92,6 +92,7 @@ public class TransactionFactory {
         transaction.setBoletoExpirationDate(DateTime.now().plusDays(4));
         transaction.setAmount(AMOUNT);
         transaction.setPaymentMethod(Transaction.PaymentMethod.BOLETO);
+
         return transaction;
     }
 }

--- a/src/test/java/me/pagarme/factory/TransactionFactory.java
+++ b/src/test/java/me/pagarme/factory/TransactionFactory.java
@@ -1,6 +1,6 @@
 package me.pagarme.factory;
 
-import org.joda.time.LocalDate;
+import org.joda.time.DateTime;
 
 import me.pagar.model.Card;
 
@@ -82,7 +82,7 @@ public class TransactionFactory {
 
         Transaction transaction = new Transaction();
 
-        transaction.setBoletoExpirationDate(LocalDate.now().plusDays(4));
+        transaction.setBoletoExpirationDate(DateTime.now().plusDays(4));
         transaction.setAmount(100);
         transaction.setPaymentMethod(Transaction.PaymentMethod.BOLETO);
         return transaction;


### PR DESCRIPTION
 -> Alteração de tipo no atributo boletoExpirationDatede de "LocalDate" para "DateTime", 
(import org.joda.time.DateTime).

Descrição do problema resolvido:

  Ao gerar o boleto, através da biblioteca java na versão 1.3.14, a data de vencimento (boleto_expiration_date) não estava sendo considerada, pois o LocalDate não possibilita o formato: Unixtimestamp ou ISODate(e.g: 2017-06-23T03:00:00.000Z) cobrado pela API, como consequência, os boletos gerados ignoravam a data informada e atribuíam a data padrão (Default: data atual + 7 dias).