### PR TITLE
Add type attribute in BankAccount class

### DIFF
--- a/src/main/java/me/pagar/BankAccountType.java
+++ b/src/main/java/me/pagar/BankAccountType.java
@@ -4,11 +4,11 @@ import com.google.gson.annotations.SerializedName;
 
 public enum BankAccountType {
     @SerializedName("conta_corrente")
-    CONTA_CORRENTE,
+    CORRENTE,
     @SerializedName("conta_poupanca")
-    CONTA_POUPANCA,
+    POUPANCA,
     @SerializedName("conta_corrente_conjunta")
-    CONTA_CORRENTE_CONJUNTA,
+    CORRENTE_CONJUNTA,
     @SerializedName("conta_poupanca_conjunta")
-    CONTA_POUPANCA_CONJUNTA
+    POUPANCA_CONJUNTA
 }

--- a/src/main/java/me/pagar/BankAccountType.java
+++ b/src/main/java/me/pagar/BankAccountType.java
@@ -1,0 +1,14 @@
+package me.pagar;
+
+import com.google.gson.annotations.SerializedName;
+
+public enum BankAccountType {
+    @SerializedName("conta_corrente")
+    CONTA_CORRENTE,
+    @SerializedName("conta_poupanca")
+    CONTA_POUPANCA,
+    @SerializedName("conta_corrente_conjunta")
+    CONTA_CORRENTE_CONJUNTA,
+    @SerializedName("conta_poupanca_conjunta")
+    CONTA_POUPANCA_CONJUNTA
+}

--- a/src/main/java/me/pagar/model/BankAccount.java
+++ b/src/main/java/me/pagar/model/BankAccount.java
@@ -8,6 +8,7 @@ import me.pagar.util.JSONUtils;
 
 import javax.ws.rs.HttpMethod;
 import java.util.Collection;
+import me.pagar.BankAccountType;
 
 public class BankAccount extends PagarMeModel<Integer> {
     @Expose(serialize = false)
@@ -43,6 +44,9 @@ public class BankAccount extends PagarMeModel<Integer> {
     @Expose
     @SerializedName("document_type")
     private DocumentType documentType;
+    @Expose
+    @SerializedName("type")
+    private BankAccountType type;
 
     public Boolean isChargeTransferFees() {
         return chargeTransferFees;
@@ -78,6 +82,10 @@ public class BankAccount extends PagarMeModel<Integer> {
 
     public DocumentType getDocumentType() {
         return documentType;
+    }
+    
+    public BankAccountType getType(){
+        return type;
     }
 
     public void setBankCode(String bankCode) {
@@ -118,6 +126,10 @@ public class BankAccount extends PagarMeModel<Integer> {
     public void setDocumentType(DocumentType documentType) {
         this.documentType = documentType;
         addUnsavedProperty("documentType");
+    }
+    public void setType(BankAccountType type){
+        this.type = type;
+        addUnsavedProperty("type");
     }
 
     public BankAccount find(int id) throws PagarMeException {
@@ -167,6 +179,7 @@ public class BankAccount extends PagarMeModel<Integer> {
         this.documentNumber = other.documentNumber;
         this.legalName = other.legalName;
         this.documentType = other.documentType;
+        this.type = other.type;
     }
 
     public enum DocumentType {

--- a/src/test/java/me/pagarme/BankAccountTest.java
+++ b/src/test/java/me/pagarme/BankAccountTest.java
@@ -6,6 +6,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import me.pagar.model.BankAccount;
+import me.pagar.model.PagarMe;
 import me.pagar.model.PagarMeException;
 import me.pagarme.factory.BankAccountFactory;
 
@@ -31,7 +32,6 @@ public class BankAccountTest extends BaseTest{
             
             BankAccount bankAccount = bankAccountFactory.create();
             BankAccount savedBankAccount = bankAccount.save();
-            
             Assert.assertNotNull(savedBankAccount.getId());
             Assert.assertEquals(savedBankAccount.getAgencia(), BankAccountFactory.DEFAULT_AGENCIA);
             Assert.assertEquals(savedBankAccount.getAgenciaDv(), BankAccountFactory.DEFAULT_AGENCIA_DV);
@@ -40,6 +40,7 @@ public class BankAccountTest extends BaseTest{
             Assert.assertEquals(savedBankAccount.getBankCode(), BankAccountFactory.DEFAULT_BANK_CODE);
             Assert.assertEquals(savedBankAccount.getDocumentNumber(), BankAccountFactory.DEFAULT_DOCUMENT_NUMBER);
             Assert.assertEquals(savedBankAccount.getLegalName(), BankAccountFactory.DEFAULT_LEGAL_NAME);
+            Assert.assertEquals(savedBankAccount.getType(), BankAccountFactory.DEFAULT_TYPE);
         } catch (Exception exception) {
             throw new UnsupportedOperationException(exception);
         }
@@ -62,6 +63,7 @@ public class BankAccountTest extends BaseTest{
             Assert.assertEquals(savedBankAccount.getBankCode(), BankAccountFactory.DEFAULT_BANK_CODE);
             Assert.assertEquals(savedBankAccount.getDocumentNumber(), BankAccountFactory.DEFAULT_DOCUMENT_NUMBER);
             Assert.assertEquals(savedBankAccount.getLegalName(), BankAccountFactory.DEFAULT_LEGAL_NAME);
+            Assert.assertEquals(savedBankAccount.getType(), BankAccountFactory.DEFAULT_TYPE);
         } catch (Exception exception) {
             throw new UnsupportedOperationException(exception);
         }
@@ -89,6 +91,7 @@ public class BankAccountTest extends BaseTest{
                 Assert.assertEquals(bankAccountVar.getBankCode(), BankAccountFactory.DEFAULT_BANK_CODE);
                 Assert.assertEquals(bankAccountVar.getDocumentNumber(), BankAccountFactory.DEFAULT_DOCUMENT_NUMBER);
                 Assert.assertEquals(bankAccountVar.getLegalName(), BankAccountFactory.DEFAULT_LEGAL_NAME);
+                Assert.assertEquals(bankAccountVar.getType(), BankAccountFactory.DEFAULT_TYPE);
             }
         } catch (Exception exception) {
             throw new UnsupportedOperationException(exception);

--- a/src/test/java/me/pagarme/factory/BankAccountFactory.java
+++ b/src/test/java/me/pagarme/factory/BankAccountFactory.java
@@ -12,7 +12,7 @@ public class BankAccountFactory {
     public static String DEFAULT_BANK_CODE = "341";
     public static String DEFAULT_LEGAL_NAME = "Conta teste";
     public static String DEFAULT_DOCUMENT_NUMBER = "18344334799";
-    public static BankAccountType DEFAULT_TYPE = BankAccountType.CONTA_CORRENTE;
+    public static BankAccountType DEFAULT_TYPE = BankAccountType.CORRENTE;
     
     
     public BankAccount create(){

--- a/src/test/java/me/pagarme/factory/BankAccountFactory.java
+++ b/src/test/java/me/pagarme/factory/BankAccountFactory.java
@@ -1,5 +1,6 @@
 package me.pagarme.factory;
 
+import me.pagar.BankAccountType;
 import me.pagar.model.BankAccount;
 
 public class BankAccountFactory {
@@ -11,6 +12,7 @@ public class BankAccountFactory {
     public static String DEFAULT_BANK_CODE = "341";
     public static String DEFAULT_LEGAL_NAME = "Conta teste";
     public static String DEFAULT_DOCUMENT_NUMBER = "18344334799";
+    public static BankAccountType DEFAULT_TYPE = BankAccountType.CONTA_CORRENTE;
     
     
     public BankAccount create(){
@@ -22,7 +24,7 @@ public class BankAccountFactory {
         bankAccount.setContaDv(DEFAULT_CONTA_DV);
         bankAccount.setLegalName(DEFAULT_LEGAL_NAME);
         bankAccount.setDocumentNumber(DEFAULT_DOCUMENT_NUMBER);
-        
+        bankAccount.setType(DEFAULT_TYPE);
         return bankAccount;
     }
 }


### PR DESCRIPTION
Create a enum named BankAccountType responsible to value the attribute type added on BankAccount class. The BankAccountType enum can assume four values: "conta-corrente", "conta-corrente-conjunta", "conta-poupanca" e "conta-poupanca-conjunta" .
Tests changed to support the attribute type added on BankAccount class. 
