### PR TITLE
Hotfix/boleto expiration date on response object

### DIFF
--- a/src/main/java/me/pagar/model/Transaction.java
+++ b/src/main/java/me/pagar/model/Transaction.java
@@ -348,8 +348,7 @@ public class Transaction extends PagarMeModel<Integer> {
     /**
      * Data de expiração do boleto (em ISODate)
      */
-    @Expose(deserialize = false)
-    @SerializedName("boleto_expiration_date")
+    @Expose
     private DateTime boletoExpirationDate;
 
     /**
@@ -1146,6 +1145,7 @@ public class Transaction extends PagarMeModel<Integer> {
         this.paymentMethod = other.paymentMethod;
         this.boletoUrl = other.boletoUrl;
         this.boletoBarcode = other.boletoBarcode;
+        this.boletoExpirationDate = other.boletoExpirationDate;
         this.referer = other.referer;
         this.ip = other.ip;
         this.cardId = other.cardId;

--- a/src/test/java/me/pagarme/transaction/TransactionTest.java
+++ b/src/test/java/me/pagarme/transaction/TransactionTest.java
@@ -305,7 +305,9 @@ public class TransactionTest extends BaseTest {
         transaction.setBoletoExpirationDate(DateTime.now().plusDays(4));
         transaction.save();
 
-        Assert.assertEquals(transaction.getBoletoExpirationDate().toLocalDate(), DateTime.now().plusDays(4).toLocalDate() );
+        Transaction foundTransaction = new Transaction().find(transaction.getId());
+
+        Assert.assertEquals(DateTime.now().plusDays(4).withTime(2, 0, 0, 0), foundTransaction.getBoletoExpirationDate());
     }
 
     @Test


### PR DESCRIPTION
This PR fix the `getBoletoExpirationDate` method that used to always return `null`.