### PR TITLE
New status added.

### DIFF
--- a/src/main/java/me/pagar/model/Payable.java
+++ b/src/main/java/me/pagar/model/Payable.java
@@ -230,7 +230,10 @@ public class Payable extends PagarMeModel<Integer> {
         WAITING_FUNDS,
         
         @SerializedName("suspended")
-        SUSPENDED
+        SUSPENDED,
+
+        @SerializedName("prepaid")
+        PREPAID
         
     }
 


### PR DESCRIPTION
Including the status PREPAID in the Payable class.

We received a case (07550454) where the client informs that there is no PREPAID status and this was generating error in your application.