### PR TITLE
Fix soft descriptor test

### DIFF
--- a/src/test/java/me/pagarme/SubscriptionTest.java
+++ b/src/test/java/me/pagarme/SubscriptionTest.java
@@ -100,7 +100,7 @@ public class SubscriptionTest extends BaseTest {
 
         Assert.assertEquals("some_metadata", foundSubscription.getMetadata().keySet().iterator().next());
         Assert.assertEquals("123456", foundSubscription.getMetadata().values().iterator().next());
-        Assert.assertEquals("some description", foundSubscription.getSoftDescriptor());
+        Assert.assertEquals("soft_test", foundSubscription.getSoftDescriptor());
     }
 
     /*

--- a/src/test/java/me/pagarme/factory/SubscriptionFactory.java
+++ b/src/test/java/me/pagarme/factory/SubscriptionFactory.java
@@ -7,7 +7,7 @@ import me.pagar.model.Subscription;
 
 public class SubscriptionFactory {
     private final Map<String, Object> METADATA =  new HashMap<String, Object>();
-    private final String SOFTDESCRIPTOR = "some description";
+    private final String SOFTDESCRIPTOR = "soft_test";
 
     public Subscription createCreditCardSubscription(String planId, String cardId, Customer customer){
         Subscription subscription = new Subscription();


### PR DESCRIPTION
Changing the soft descriptor default text to less than 13 characters.
 