### PR TITLE
Adding recipient anticipation parameters and its tests

### DIFF
--- a/src/main/java/me/pagar/AutoAnticipationType.java
+++ b/src/main/java/me/pagar/AutoAnticipationType.java
@@ -1,0 +1,15 @@
+package me.pagar;
+/**
+ *
+ * @author LucasVale
+ */
+import com.google.gson.annotations.SerializedName;
+
+public enum AutoAnticipationType {
+    @SerializedName("full")
+    FULL,
+
+    @SerializedName("1025")
+    TENTWENTYFIVE,
+
+}

--- a/src/main/java/me/pagar/model/Recipient.java
+++ b/src/main/java/me/pagar/model/Recipient.java
@@ -18,6 +18,7 @@ import me.pagar.model.BulkAnticipation.Timeframe;
 import me.pagar.util.DateTimeTimestampAdapter;
 import me.pagar.util.JSONUtils;
 import me.pagar.RecipientStatus;
+import me.pagar.AutoAnticipationType;
 
 public class Recipient  extends PagarMeModel<String> {
 
@@ -36,6 +37,18 @@ public class Recipient  extends PagarMeModel<String> {
     @Expose
     @SerializedName(value = "anticipatable_volume_percentage")
     private Integer anticipatableVolumePercentage;
+
+    @Expose
+    @SerializedName(value = "automatic_anticipation_type")
+    private AutoAnticipationType automaticAnticipationType;
+
+    @Expose
+    @SerializedName(value = "automatic_anticipation_days")
+    private String automaticAnticipationDays;
+
+    @Expose
+    @SerializedName(value = "automatic_anticipation_1025_delay")
+    private Integer automaticAnticipationDelay;
 
     @Expose
     @SerializedName(value = "transfer_day")
@@ -67,11 +80,25 @@ public class Recipient  extends PagarMeModel<String> {
     public Boolean isTransferEnabled() {
         return transferEnabled;
     }
+
     public RecipientStatus getStatus() {
         return status;
     }
+
     public Integer getAnticipatableVolumePercentage() {
         return anticipatableVolumePercentage;
+    }
+
+    public AutoAnticipationType getAutomaticAnticipationType() {
+        return automaticAnticipationType;
+    }
+
+    public String getAutomaticAnticipationDays() {
+        return automaticAnticipationDays;
+    }
+
+    public Integer getAutomaticAnticipationDelay() {
+        return automaticAnticipationDelay;
     }
 
     public Integer getTransferDay() {
@@ -101,6 +128,21 @@ public class Recipient  extends PagarMeModel<String> {
     public void setStatus(RecipientStatus status) {
         this.status = status;
         addUnsavedProperty("status");
+    }
+
+    public void setAutomaticAnticipationType(AutoAnticipationType automaticAnticipationType) {
+        this.automaticAnticipationType = automaticAnticipationType;
+        addUnsavedProperty("automaticAnticipationType");
+    }
+
+    public void setAutomaticAnticipationDays(String automaticAnticipationDays) {
+        this.automaticAnticipationDays = automaticAnticipationDays;
+        addUnsavedProperty("automaticAnticipationDays");
+    }
+
+    public void setAutomaticAnticipationDelay(Integer automaticAnticipationDelay) {
+        this.automaticAnticipationDelay = automaticAnticipationDelay;
+        addUnsavedProperty("automaticAnticipationDelay");
     }
 
     public void setAutomaticAnticipationEnabled(Boolean automaticAnticipationEnabled) {
@@ -258,6 +300,9 @@ public class Recipient  extends PagarMeModel<String> {
         this.updatedAt = other.updatedAt;
         this.bankAccount = other.bankAccount;
         this.status = other.status;
+        this.automaticAnticipationType = other.automaticAnticipationType;
+        this.automaticAnticipationDays = other.automaticAnticipationDays;
+        this.automaticAnticipationDelay = other.automaticAnticipationDelay;
     }
 
     public enum TransferInterval {

--- a/src/test/java/me/pagarme/RecipientTest.java
+++ b/src/test/java/me/pagarme/RecipientTest.java
@@ -122,7 +122,7 @@ public class RecipientTest extends BaseTest{
         recipient = recipient.save(); 
         Assert.assertEquals(recipient.getStatus(), RecipientStatus.INACTIVE);
 
-        }
+    }
         
     @Test
     public void testChangeRecipientAutomaticAnticipationType() throws PagarMeException {
@@ -138,6 +138,6 @@ public class RecipientTest extends BaseTest{
         recipient.setAutomaticAnticipationType(AutoAnticipationType.FULL);
         recipient = recipient.save(); 
         Assert.assertEquals(recipient.getAutomaticAnticipationType(), AutoAnticipationType.FULL);
-        }
+    }
 
 }

--- a/src/test/java/me/pagarme/RecipientTest.java
+++ b/src/test/java/me/pagarme/RecipientTest.java
@@ -3,6 +3,7 @@ package me.pagarme;
 
 import java.util.Collection;
 import me.pagar.RecipientStatus;
+import me.pagar.AutoAnticipationType;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -41,6 +42,9 @@ public class RecipientTest extends BaseTest{
         Assert.assertEquals(recipient.isTransferEnabled(), RecipientFactory.DEFAULT_TRANSFER_ENABLED);
         Assert.assertEquals(recipient.getAutomaticAnticipationEnabled(), RecipientFactory.DEFAULT_AUTOMATIC_ANTICIPATION_ENABLED);
         Assert.assertEquals(recipient.getStatus(), RecipientFactory.DEFAULT_STATUS);
+        Assert.assertEquals(recipient.getAutomaticAnticipationType(), RecipientFactory.DEFAULT_AUTOANTICIPATIONTYPE);
+        Assert.assertEquals(recipient.getAutomaticAnticipationDays(), RecipientFactory.DEFAULT_AUTOANTICIPATIONDAYS);
+        Assert.assertEquals(recipient.getAutomaticAnticipationDelay(), RecipientFactory.DEFAULT_AUTOANTICIPATIONDELAY);
 
         int recipientBankAccountId = recipient.getBankAccount().getId();
         Assert.assertEquals(recipientBankAccountId, bankAccountId);
@@ -118,6 +122,22 @@ public class RecipientTest extends BaseTest{
         recipient = recipient.save(); 
         Assert.assertEquals(recipient.getStatus(), RecipientStatus.INACTIVE);
 
-       }
+        }
+        
+    @Test
+    public void testChangeRecipientAutomaticAnticipationType() throws PagarMeException {
+
+        int bankAccountId = bankAccountFactory.create().save().getId();
+        Recipient recipient = recipientFactory.create();
+        recipient.setBankAccountId(bankAccountId);
+
+        recipient.save();
+        recipient.setAutomaticAnticipationType(AutoAnticipationType.TENTWENTYFIVE);
+        recipient = recipient.save(); 
+        Assert.assertEquals(recipient.getAutomaticAnticipationType(), AutoAnticipationType.TENTWENTYFIVE);
+        recipient.setAutomaticAnticipationType(AutoAnticipationType.FULL);
+        recipient = recipient.save(); 
+        Assert.assertEquals(recipient.getAutomaticAnticipationType(), AutoAnticipationType.FULL);
+        }
 
 }

--- a/src/test/java/me/pagarme/factory/RecipientFactory.java
+++ b/src/test/java/me/pagarme/factory/RecipientFactory.java
@@ -4,6 +4,7 @@ import me.pagar.model.BankAccount;
 import me.pagar.model.Recipient;
 import me.pagar.RecipientStatus;
 import me.pagar.model.Recipient.TransferInterval;
+import me.pagar.AutoAnticipationType;
 
 public class RecipientFactory {
 
@@ -12,6 +13,9 @@ public class RecipientFactory {
     public static final Boolean DEFAULT_AUTOMATIC_ANTICIPATION_ENABLED = true;
     public static final TransferInterval DEFAULT_TRANSFER_INTERVAL = TransferInterval.WEEKLY;
     public static final RecipientStatus DEFAULT_STATUS = RecipientStatus.ACTIVE;
+    public static final AutoAnticipationType DEFAULT_AUTOANTICIPATIONTYPE = AutoAnticipationType.FULL;
+    public static final String DEFAULT_AUTOANTICIPATIONDAYS = "[1]";
+    public static final Integer DEFAULT_AUTOANTICIPATIONDELAY = 30;
     private BankAccountFactory bankAccountFactory = new BankAccountFactory();
     
     public Recipient create(){
@@ -23,6 +27,9 @@ public class RecipientFactory {
         recipient.setTransferInterval(TransferInterval.WEEKLY);
         recipient.setAutomaticAnticipationEnabled(DEFAULT_AUTOMATIC_ANTICIPATION_ENABLED);
         recipient.setStatus(DEFAULT_STATUS);
+        recipient.setAutomaticAnticipationType(DEFAULT_AUTOANTICIPATIONTYPE);
+        recipient.setAutomaticAnticipationDays(DEFAULT_AUTOANTICIPATIONDAYS);
+        recipient.setAutomaticAnticipationDelay(DEFAULT_AUTOANTICIPATIONDELAY);
         return recipient;
     }
 }


### PR DESCRIPTION
Adicionando os parâmetros `automatic_anticipation_type`, `automatic_anticipation_days` e `automatic_anticipation_1025_delay` para permitir maior facilidade de automatização na criação de novos recebedores com o SDK de JAVA.

Também foram modificados e adicionados testes para verificar o funcionamento desses parametros.