### PR TITLE
feat: Remove build param from BulkAntecipation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>me.pagar</groupId>
   <artifactId>pagarme-java</artifactId>
-  <version>2.4</version>
+  <version>2.5</version>
   <name>pagarme-java</name>
   <description>Pagar.me Java Bindings</description>
   <url>https://github.com/pagarme/pagarme-java</url>

--- a/src/main/java/me/pagar/model/BulkAnticipation.java
+++ b/src/main/java/me/pagar/model/BulkAnticipation.java
@@ -1,8 +1,5 @@
 package me.pagar.model;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.joda.time.DateTime;
 
 import com.google.gson.annotations.Expose;
@@ -28,8 +25,6 @@ public class BulkAnticipation extends PagarMeModel<String> {
 
     @Expose(deserialize=false)
     private Integer requestedAmount;
-    @Expose(deserialize = false)
-    private Boolean build;
 
     public DateTime getPaymentDate() {
         return paymentDate;
@@ -63,22 +58,15 @@ public class BulkAnticipation extends PagarMeModel<String> {
         return anticipationFee;
     }
 
-    public Boolean getBuild() {
-        return build;
-    }
-
     public void setRequiredParametersForAnticipationLimit(DateTime paymentDate, Timeframe timeframe){
         this.paymentDate = paymentDate;
         this.timeframe = timeframe;
     }
 
-    public void setRequiredParametersForCreation(DateTime paymentDate, Timeframe timeframe, Integer requestedAmount, Boolean build){
+    public void setRequiredParametersForCreation(DateTime paymentDate, Timeframe timeframe, Integer requestedAmount){
         this.paymentDate = paymentDate;
         this.timeframe = timeframe;
         this.requestedAmount = requestedAmount;
-        if(build){
-            this.build = build;
-        }
     }
 
     public enum Status{

--- a/src/main/java/me/pagar/model/Recipient.java
+++ b/src/main/java/me/pagar/model/Recipient.java
@@ -246,13 +246,6 @@ public class Recipient  extends PagarMeModel<String> {
         return newAnticipation;
     }
 
-    public void deleteAnticipation(BulkAnticipation anticipation) throws PagarMeException{
-        validateId();
-        String path = String.format("/%s/%s/%s/%s", getClassName(), getId(), anticipation.getClassName(), anticipation.getId());
-        final PagarMeRequest request = new PagarMeRequest(HttpMethod.DELETE, path);
-        request.execute();
-    }
-
     public BulkAnticipation cancelAnticipation(BulkAnticipation anticipation) throws PagarMeException{
         validateId();
         String path = String.format("/%s/%s/%s/%s/cancel", getClassName(), getId(), anticipation.getClassName(), anticipation.getId());
@@ -260,15 +253,6 @@ public class Recipient  extends PagarMeModel<String> {
         JsonObject response = request.execute();
         BulkAnticipation canceledAnticipation = JSONUtils.getAsObject(response, BulkAnticipation.class);
         return canceledAnticipation;
-    }
-
-    public BulkAnticipation confirmBulkAnticipation(BulkAnticipation anticipation) throws PagarMeException{
-        validateId();
-        String path = String.format("/%s/%s/%s/%s/confirm", getClassName(), getId(), anticipation.getClassName(), anticipation.getId());
-        final PagarMeRequest request = new PagarMeRequest(HttpMethod.POST, path);
-        JsonObject response = request.execute();
-        BulkAnticipation confirmedAnticipation = JSONUtils.getAsObject(response, BulkAnticipation.class);
-        return confirmedAnticipation;
     }
 
     public Collection<BulkAnticipation> findAnticipations(int count, int page) throws PagarMeException{

--- a/src/test/java/me/pagarme/AnticipationTest.java
+++ b/src/test/java/me/pagarme/AnticipationTest.java
@@ -54,7 +54,7 @@ public class AnticipationTest extends BaseTest {
         transaction.save();
 
         BulkAnticipation anticipation = new BulkAnticipation();
-        anticipation.setRequiredParametersForCreation(PagarmeCalendar.getValidWeekday(), Timeframe.START, 1234567, false);
+        anticipation.setRequiredParametersForCreation(PagarmeCalendar.getValidWeekday(), Timeframe.START, 1234567);
         anticipation = defaultRecipient.anticipate(anticipation);
         Assert.assertNotNull(anticipation.getId());
         Assert.assertNotNull(anticipation.getAnticipationFee());
@@ -65,8 +65,8 @@ public class AnticipationTest extends BaseTest {
 
     @Test
     public void testAnticipationList() throws PagarMeException, Exception {
-        BulkAnticipationHelpers.createAnticipation(12345678, Timeframe.END, false, defaultRecipient);
-        BulkAnticipationHelpers.createAnticipation(1234567, Timeframe.END, false, defaultRecipient);
+        BulkAnticipationHelpers.createAnticipation(12345678, Timeframe.END, defaultRecipient);
+        BulkAnticipationHelpers.createAnticipation(1234567, Timeframe.END, defaultRecipient);
 
         Collection<BulkAnticipation> anticipations = defaultRecipient.findAnticipations(10, 1);
         Assert.assertEquals(2, anticipations.size());
@@ -74,30 +74,8 @@ public class AnticipationTest extends BaseTest {
 
     @Test
     public void testAnticipationCancelation() throws PagarMeException, Exception {
-        BulkAnticipation anticipation = BulkAnticipationHelpers.createAnticipation(12345678, Timeframe.END, false, defaultRecipient);
+        BulkAnticipation anticipation = BulkAnticipationHelpers.createAnticipation(12345678, Timeframe.END, defaultRecipient);
         anticipation = defaultRecipient.cancelAnticipation(anticipation);
         Assert.assertEquals(Status.CANCELED, anticipation.getStatus());
-    }
-
-    @Test
-    public void testAnticipationDeletion() throws PagarMeException, Exception {
-        BulkAnticipation anticipation = BulkAnticipationHelpers.createAnticipation(12345678, Timeframe.END, true, defaultRecipient);
-
-        Collection<BulkAnticipation> anticipations = defaultRecipient.findAnticipations(10, 1);
-        Assert.assertEquals(1, anticipations.size());
-
-        defaultRecipient.deleteAnticipation(anticipation);
-
-        anticipations = defaultRecipient.findAnticipations(10, 1);
-        Assert.assertEquals(0, anticipations.size());
-    }
-
-    @Test
-    public void testAnticipationConfirmation() throws PagarMeException, Exception {
-        BulkAnticipation anticipation = BulkAnticipationHelpers.createAnticipation(12345678, Timeframe.END, true, defaultRecipient);
-        Assert.assertEquals(Status.BUILDING, anticipation.getStatus());
-
-        anticipation = defaultRecipient.confirmBulkAnticipation(anticipation);
-        Assert.assertEquals(Status.PENDING, anticipation.getStatus());
     }
 }

--- a/src/test/java/me/pagarme/helper/BulkAnticipationHelpers.java
+++ b/src/test/java/me/pagarme/helper/BulkAnticipationHelpers.java
@@ -19,14 +19,14 @@ public class BulkAnticipationHelpers {
         return recipient.save();
     }
 
-    public static BulkAnticipation createAnticipation(Integer requestedAmount, Timeframe timeFrame, Boolean build, Recipient recipient)
+    public static BulkAnticipation createAnticipation(Integer requestedAmount, Timeframe timeFrame, Recipient recipient)
             throws PagarMeException, Exception {
         Transaction transaction = transactionFactory.createCreditCardTransactionWithoutPinMode();
         transaction.setAmount(requestedAmount);
         transaction.save();
 
         BulkAnticipation anticipation = new BulkAnticipation();
-        anticipation.setRequiredParametersForCreation(PagarmeCalendar.getValidWeekday() , timeFrame, requestedAmount, build);
+        anticipation.setRequiredParametersForCreation(PagarmeCalendar.getValidWeekday(), timeFrame, requestedAmount);
         anticipation = recipient.anticipate(anticipation);
         return anticipation;
     }


### PR DESCRIPTION
Este PR tem como objetivo remover as chamadas para: 
DELETE '/recipients/:recipient_id/bulk_anticipations/:id' 
POST '/recipients/:recipient_id/bulk_anticipations/:id/confirm'

E também remover campo 'build' do fluxo bulk_anticipation.