### PR TITLE
refactor to send apiKey as authorization header

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>me.pagar</groupId>
   <artifactId>pagarme-java</artifactId>
-  <version>2.6</version>
+  <version>2.7</version>
   <name>pagarme-java</name>
   <description>Pagar.me Java Bindings</description>
   <url>https://github.com/pagarme/pagarme-java</url>
@@ -184,6 +184,13 @@
             <serverId>ossrh</serverId>
             <nexusUrl>https://oss.sonatype.org</nexusUrl>
             <autoReleaseAfterClose>true</autoReleaseAfterClose>
+          </configuration>
+        </plugin>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <configuration>
+            <source>11</source>
+            <target>11</target>
           </configuration>
         </plugin>
       </plugins>

--- a/src/main/java/me/pagar/model/PagarMe.java
+++ b/src/main/java/me/pagar/model/PagarMe.java
@@ -5,6 +5,7 @@ import com.google.common.base.Strings;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import java.net.URLDecoder;
+import java.util.Base64;
 import java.util.Formatter;
 
 public abstract class PagarMe {
@@ -29,6 +30,8 @@ public abstract class PagarMe {
 
     private static String apiKey;
 
+    private static String password;
+
     public static String fullApiUrl(final String path) {
         return ENDPOINT.concat("/")
                 .concat(API_VERSION)
@@ -39,8 +42,19 @@ public abstract class PagarMe {
         return apiKey;
     }
 
+    public static String getBasicAuth() {
+        String auth = apiKey + ":" + password;
+        return "Basic " + Base64.getEncoder().encodeToString(auth.getBytes());
+    }
+
     public static void init(String apiKey) {
         PagarMe.apiKey = apiKey;
+        PagarMe.password = "";
+    }
+
+    public static void init(String apiKey, String password) {
+        PagarMe.apiKey = apiKey;
+        PagarMe.password = password;
     }
 
     public static boolean validateRequestSignature(final String payload, final String signature) {

--- a/src/main/java/me/pagar/model/RestClient.java
+++ b/src/main/java/me/pagar/model/RestClient.java
@@ -19,8 +19,6 @@ import java.util.Map;
 
 public class RestClient {
 
-    public final static String API_KEY = "api_key";
-
     public final static String AMOUNT = "amount";
 
     private HttpsURLConnection httpClient;
@@ -97,6 +95,7 @@ public class RestClient {
         headers.put("User-Agent", sdkVersion);
         headers.put("X-PagarMe-User-Agent", sdkVersion);
         headers.put("Accept", "application/json");
+        headers.put("Authorization", PagarMe.getBasicAuth());
 
         if (Strings.isNullOrEmpty(url)) {
             throw new PagarMeException("You must set the URL to make a request.");
@@ -106,8 +105,6 @@ public class RestClient {
 
             try {
                 final UriBuilder builder = UriBuilder.fromPath(this.url);
-
-                builder.queryParam(API_KEY, PagarMe.getApiKey());
 
                 if (this.parameters.containsKey(AMOUNT) && this.parameters.size() == 1) {
                     builder.queryParam(AMOUNT, this.parameters.remove(AMOUNT));


### PR DESCRIPTION
Ajuste para enviar a apiKey como basic auth no header. Formato username:password. O padrão é que o password seja vazio, mas deixei preparado um init caso tenha algum valor no password pra passar.